### PR TITLE
MRG: Allow for realpath differences in listdeps

### DIFF
--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -10,7 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 import os
 from os.path import (dirname, join as pjoin, isfile, abspath, realpath,
-                     basename, exists, splitext)
+                     basename, exists, splitext, sep as psep)
 import shutil
 from typing import Text
 
@@ -62,14 +62,16 @@ DATA_PATH = abspath(pjoin(dirname(__file__), 'data'))
 
 def test_listdeps():
     # smokey tests of list dependencies command
-    # Paths have common prefix stripped.
     libext_rpath = realpath(pjoin(DATA_PATH, 'libextfunc2_rpath.dylib'))
-    rp_cwd = realpath(os.getcwd())
+    rp_cwd = realpath(os.getcwd()) + psep
+    # Replicate path stripping.
+    if libext_rpath.startswith(rp_cwd):
+        libext_rpath = libext_rpath[len(rp_cwd):]
     local_libs = {
         'liba.dylib',
         'libb.dylib',
         'libc.dylib',
-        libext_rpath[(len(rp_cwd) + 1):],
+        libext_rpath,
     }
     # single path, with libs
     code, stdout, stderr = run_command(['delocate-listdeps', DATA_PATH])

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -10,7 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 import os
 from os.path import (dirname, join as pjoin, isfile, abspath, realpath,
-                     basename, exists, splitext, relpath)
+                     basename, exists, splitext)
 import shutil
 from typing import Text
 

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -64,13 +64,12 @@ def test_listdeps():
     # smokey tests of list dependencies command
     # Paths have common prefix stripped.
     libext_rpath = realpath(pjoin(DATA_PATH, 'libextfunc2_rpath.dylib'))
-    local_libs = set(['liba.dylib', 'libb.dylib', 'libc.dylib',
-                      relpath(libext_rpath, realpath(os.getcwd()))])
+    rp_cwd = realpath(os.getcwd())
     local_libs = {
         'liba.dylib',
         'libb.dylib',
         'libc.dylib',
-        relpath(libext_rpath, realpath(os.getcwd())),
+        libext_rpath[(len(rp_cwd) + 1):],
     }
     # single path, with libs
     code, stdout, stderr = run_command(['delocate-listdeps', DATA_PATH])

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -10,7 +10,7 @@ from __future__ import division, print_function, absolute_import
 
 import os
 from os.path import (dirname, join as pjoin, isfile, abspath, realpath,
-                     basename, exists, splitext)
+                     basename, exists, splitext, relpath)
 import shutil
 from typing import Text
 
@@ -62,11 +62,15 @@ DATA_PATH = abspath(pjoin(dirname(__file__), 'data'))
 
 def test_listdeps():
     # smokey tests of list dependencies command
+    # Paths have common prefix stripped.
+    libext_rpath = realpath(pjoin(DATA_PATH, 'libextfunc2_rpath.dylib'))
+    local_libs = set(['liba.dylib', 'libb.dylib', 'libc.dylib',
+                      relpath(libext_rpath, realpath(os.getcwd()))])
     local_libs = {
         'liba.dylib',
         'libb.dylib',
         'libc.dylib',
-        pjoin(DATA_PATH, 'libextfunc2_rpath.dylib'),
+        relpath(libext_rpath, realpath(os.getcwd())),
     }
     # single path, with libs
     code, stdout, stderr = run_command(['delocate-listdeps', DATA_PATH])


### PR DESCRIPTION
I was getting an error locally running the tests, because my code
directory realpath differs from the apparent path.